### PR TITLE
Fixes #4 by deferring wire begin call, provides the files needed to meet the Arduino library spec

### DIFF
--- a/AT24CX.cpp
+++ b/AT24CX.cpp
@@ -112,13 +112,22 @@ AT24C512::AT24C512(byte index) {
 void AT24CX::init(byte index, byte pageSize) {
 	_id = AT24CX_ID | (index & 0x7);
 	_pageSize = pageSize;
-	Wire.begin();
+	_wireLibStarted = false;
 }
+
+void AT24CX::startWireIfNeeded() {
+	if(!_wireLibStarted) {
+		_wireLibStarted = true;
+		Wire.begin();
+	}
+}
+
 
 /**
  * Write byte
  */
 void AT24CX::write(unsigned int address, byte data) {
+	startWireIfNeeded();
     Wire.beginTransmission(_id);
     if(Wire.endTransmission()==0) {
     	Wire.beginTransmission(_id);
@@ -231,6 +240,7 @@ void AT24CX::write(unsigned int address, byte *data, int n) {
  * Write sequence of n bytes from offset
  */
 void AT24CX::write(unsigned int address, byte *data, int offset, int n) {
+	startWireIfNeeded();
     Wire.beginTransmission(_id);
     if (Wire.endTransmission()==0) {
      	Wire.beginTransmission(_id);
@@ -249,6 +259,7 @@ void AT24CX::write(unsigned int address, byte *data, int offset, int n) {
 byte AT24CX::read(unsigned int address) {
 	byte b = 0;
 	int r = 0;
+	startWireIfNeeded();
 	Wire.beginTransmission(_id);
     if (Wire.endTransmission()==0) {
      	Wire.beginTransmission(_id);
@@ -289,6 +300,7 @@ void AT24CX::read(unsigned int address, byte *data, int n) {
  * Read sequence of n bytes to offset
  */
 void AT24CX::read(unsigned int address, byte *data, int offset, int n) {
+	startWireIfNeeded();
 	Wire.beginTransmission(_id);
     if (Wire.endTransmission()==0) {
      	Wire.beginTransmission(_id);

--- a/AT24CX.h
+++ b/AT24CX.h
@@ -60,11 +60,13 @@ public:
 protected:
 	void init(byte index, byte pageSize);
 private:
+	void startWireIfNeeded();
 	void read(unsigned int address, byte *data, int offset, int n);
 	void write(unsigned int address, byte *data, int offset, int n);
 	int _id;
 	byte _b[8];
 	byte _pageSize;
+	byte _wireLibStarted;
 };
 
 // AT24C32 class definiton

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,42 @@
+#######################################
+# Syntax Coloring Map For AT24Cx lib
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+AT24CX		KEYWORD1
+AT24CX32	KEYWORD1
+AT24CX64	KEYWORD1
+AT24CX128	KEYWORD1
+AT24CX256	KEYWORD1
+AT24CX512	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+write		KEYWORD2
+writeInt	KEYWORD2
+writeLong	KEYWORD2
+writeFloat	KEYWORD2
+writeDouble	KEYWORD2
+writeChars	KEYWORD2
+
+read		KEYWORD2
+readInt		KEYWORD2
+readLong	KEYWORD2
+readFloat	KEYWORD2
+readDouble	KEYWORD2
+readChars	KEYWORD2
+
+#######################################
+# Instances (KEYWORD2)
+#######################################
+
+
+
+#######################################
+# Constants (LITERAL1)
+#######################################

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,8 @@
+name=AT24CX
+version=0.1
+maintainer=https://github.com/cyberp/AT24Cx
+author=cyberp
+category=Data Storage
+url=https://github.com/cyberp/AT24Cx
+sentence=Provides support for I2C eeprom storage based on the popular AT24 eeprom ICs
+paragraph=Provides support for I2C eeprom storage based on the popular AT24 eeprom ICs


### PR DESCRIPTION
Without the properties file I could not seem to get sloeber (the eclipse Arduino IDE) to load the library into my project. Also, In this PR are the minimum basic changes needed for the library to work in Sloeber and also to do basic  syntax highlighting in the Arduino IDE.

I've also deferred the Wire.begin() call to the first read or write, this makes the library work with newer versions of Arduino and boards. It previously often failed to start because wire begin was called before the setup method started - this was because it was called in the constructor of what was generally a global variable.